### PR TITLE
Binary Release

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -34,7 +34,7 @@ jobs:
           git clone --recurse-submodules --depth 1 --shallow-submodules git@github.com:CoLearn-Dev/colink-protocol-registry-dev.git
       - name: Compile
         run: | 
-          yes n | ./colinkctl install
+          printf "n\nn" | ./colinkctl install
       - name: Pack
         run: |
           tar -pcf colink.tar colinkctl colink-*

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -34,7 +34,7 @@ jobs:
           git clone --recurse-submodules --depth 1 --shallow-submodules git@github.com:CoLearn-Dev/colink-protocol-registry-dev.git
       - name: Compile
         run: | 
-          printf "n\nn" | ./colinkctl install
+          ./compile_release.sh
       - name: Pack
         run: |
           tar -pcf colink.tar colinkctl colink-*/target/release/colink-*[!.]

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -37,7 +37,7 @@ jobs:
           ./compile_release.sh
       - name: Pack
         run: |
-          tar -pcf colink.tar colinkctl colink-*/target/release/colink-*[!.]
+          tar -pcf colink.tar colinkctl colink-*/target/release/colink-*[!.] colink-*/target/release/examples
           cat install_colink.template.sh colink.tar > install_colink.sh
       - name: Get RELEASE_NAME
         run: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -37,7 +37,7 @@ jobs:
           printf "n\nn" | ./colinkctl install
       - name: Pack
         run: |
-          tar -pcf colink.tar colinkctl colink-*
+          tar -pcf colink.tar colinkctl colink-*/target/release/colink-*[!.]
           cat install_colink.template.sh colink.tar > install_colink.sh
       - name: Get RELEASE_NAME
         run: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -32,6 +32,9 @@ jobs:
           git clone --recurse-submodules --depth 1 --shallow-submodules git@github.com:CoLearn-Dev/colink-protocol-policy-module-dev.git
           git clone --recurse-submodules --depth 1 --shallow-submodules git@github.com:CoLearn-Dev/colink-protocol-remote-storage-dev.git
           git clone --recurse-submodules --depth 1 --shallow-submodules git@github.com:CoLearn-Dev/colink-protocol-registry-dev.git
+      - name: Compile
+        run: | 
+          yes n | ./colinkctl install
       - name: Pack
         run: |
           tar -pcf colink.tar colinkctl colink-*

--- a/colinkctl
+++ b/colinkctl
@@ -77,7 +77,7 @@ start() {
     fi
     read -r -p "Enter the port number for colink server [8080]:" port
     port=${port:-8080}
-    nohup cargo run -- --address "0.0.0.0" --port $port --mq-amqp amqp://guest:guest@localhost:5672 --mq-api http://guest:guest@localhost:15672/api --mq-prefix $mq_prefix >/dev/null 2>&1 & echo -n $! > pid.txt
+    nohup ./target/release/colink-server --address "0.0.0.0" --port $port --mq-amqp amqp://guest:guest@localhost:5672 --mq-api http://guest:guest@localhost:15672/api --mq-prefix $mq_prefix >/dev/null 2>&1 & echo -n $! > pid.txt
     pid=`cat pid.txt`
     for i in {1..600}; do
         sleep 0.1
@@ -137,7 +137,7 @@ create_users() {
     cd colink-sdk-rust-dev
     read -p "Enter the number of users you want to create [2]:" user_num
     user_num=${user_num:-2}
-    cargo run --example host_import_users http://127.0.0.1:$port $host_token $user_num > user_token.txt
+    ./target/release/examples/host_import_users http://127.0.0.1:$port $host_token $user_num > user_token.txt
     cat user_token.txt
     cat user_token.txt >> ../user_token.txt
     cd ..
@@ -215,8 +215,8 @@ _enable_policy_module() {
     cd colink-protocol-policy-module-dev
     cat ../user_token.txt | while read line
     do
-        cargo run --example start_policy_module http://127.0.0.1:$port $line
-        cargo run --example accept_all_tasks http://127.0.0.1:$port $line
+        ./target/release/examples/start_policy_module start_policy_module http://127.0.0.1:$port $line
+        ./target/release/examples/accept_all_tasks http://127.0.0.1:$port $line
     done
     cd ..
 }
@@ -226,21 +226,21 @@ ceate_local_registry() {
     port=`cat port.txt`
     host_token=`cat host_token.txt`
     cd colink-sdk-rust-dev
-    cargo run --example host_import_users http://127.0.0.1:$port $host_token 1 > local_registry_token.txt
+    ./target/release/examples/host_import_users http://127.0.0.1:$port $host_token 1 > local_registry_token.txt
     cat local_registry_token.txt > ../local_registry_token.txt
     cd ..
     registry_token=`cat local_registry_token.txt`
     cd colink-protocol-policy-module-dev
-    nohup cargo run -- --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
-    cargo run --example start_policy_module http://127.0.0.1:$port $registry_token
-    cargo run --example accept_all_tasks http://127.0.0.1:$port $registry_token
+    nohup ./target/release/colink-protocol-policy-module --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
+    ./target/release/examples/start_policy_module http://127.0.0.1:$port $registry_token
+    ./target/release/examples/accept_all_tasks http://127.0.0.1:$port $registry_token
     cd ..
     cd colink-protocol-remote-storage-dev
-    nohup cargo run -- --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
+    nohup ./target/release/colink-protocol-remote-storage --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
     cd ..
     cd colink-protocol-registry-dev
-    nohup cargo run -- --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
-    cargo run --example update_registries http://127.0.0.1:$port $registry_token $registry_token
+    nohup ./target/release/colink-protocol-registry --addr http://127.0.0.1:$port --jwt $registry_token >/dev/null 2>&1 & echo $! >> ../local_registry_pid.txt
+    ./target/release/examples/update_registries http://127.0.0.1:$port $registry_token $registry_token
     cd ..
 }
 
@@ -326,7 +326,7 @@ enable_dev_env() {
                         cd colink-protocol-registry-dev
                         cat ../user_token.txt | while read line
                         do
-                            cargo run --example update_registries http://127.0.0.1:$port $line $registry_token
+                            ./target/release/examples/update_registries http://127.0.0.1:$port $line $registry_token
                         done
                         cd ..
                         ;;

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -1,0 +1,33 @@
+if ! [ -d "./colink-server-dev" ]; then
+    git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.git
+fi
+cd colink-server-dev
+cargo build --all-targets --release
+cd ..
+if ! [ -d "./colink-sdk-rust-dev" ]; then
+    git clone --recursive git@github.com:CoLearn-Dev/colink-sdk-rust-dev.git
+fi
+cd colink-sdk-rust-dev
+cargo build --all-targets --release
+cd ..
+if ! [ -d "./colink-protocol-policy-module-dev" ]; then
+    git clone --recursive git@github.com:CoLearn-Dev/colink-protocol-policy-module-dev.git
+fi
+cd colink-protocol-policy-module-dev
+sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo build --all-targets --release
+cd ..
+if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
+    git clone --recursive git@github.com:CoLearn-Dev/colink-protocol-remote-storage-dev.git
+fi
+cd colink-protocol-remote-storage-dev
+sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo build --all-targets --release
+cd ..
+if ! [ -d "./colink-protocol-registry-dev" ]; then
+    git clone --recursive git@github.com:CoLearn-Dev/colink-protocol-registry-dev.git
+fi
+cd colink-protocol-registry-dev
+sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo build --all-targets --release
+cd ..

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -2,12 +2,16 @@ if ! [ -d "./colink-server-dev" ]; then
     git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.git
 fi
 cd colink-server-dev
+cargo vendor all
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-sdk-rust-dev" ]; then
     git clone --recursive git@github.com:CoLearn-Dev/colink-sdk-rust-dev.git
 fi
 cd colink-sdk-rust-dev
+cargo vendor all
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-policy-module-dev" ]; then
@@ -15,6 +19,8 @@ if ! [ -d "./colink-protocol-policy-module-dev" ]; then
 fi
 cd colink-protocol-policy-module-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo vendor all
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
@@ -22,6 +28,8 @@ if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
 fi
 cd colink-protocol-remote-storage-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo vendor all
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-registry-dev" ]; then
@@ -29,5 +37,7 @@ if ! [ -d "./colink-protocol-registry-dev" ]; then
 fi
 cd colink-protocol-registry-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
+cargo vendor all
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
 cargo build --all-targets --release
 cd ..

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -1,9 +1,9 @@
 if ! [ -d "./colink-server-dev" ]; then
-    git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.git
+    git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.gittoml
 fi
 cd colink-server-dev
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-sdk-rust-dev" ]; then
@@ -11,7 +11,7 @@ if ! [ -d "./colink-sdk-rust-dev" ]; then
 fi
 cd colink-sdk-rust-dev
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-policy-module-dev" ]; then
@@ -20,7 +20,7 @@ fi
 cd colink-protocol-policy-module-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
@@ -29,7 +29,7 @@ fi
 cd colink-protocol-remote-storage-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-registry-dev" ]; then
@@ -38,6 +38,6 @@ fi
 cd colink-protocol-registry-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> cargo.toml
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -1,9 +1,10 @@
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> ~/.cargo/config.toml
 if ! [ -d "./colink-server-dev" ]; then
     git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.gittoml
 fi
 cd colink-server-dev
 cargo vendor all
+mkdir .cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> .cargo/config.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-sdk-rust-dev" ]; then
@@ -11,6 +12,8 @@ if ! [ -d "./colink-sdk-rust-dev" ]; then
 fi
 cd colink-sdk-rust-dev
 cargo vendor all
+mkdir .cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> .cargo/config.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-policy-module-dev" ]; then
@@ -19,6 +22,8 @@ fi
 cd colink-protocol-policy-module-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
+mkdir .cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> .cargo/config.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
@@ -27,6 +32,8 @@ fi
 cd colink-protocol-remote-storage-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
+mkdir .cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> .cargo/config.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-registry-dev" ]; then
@@ -35,5 +42,7 @@ fi
 cd colink-protocol-registry-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
+mkdir .cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> .cargo/config.toml
 cargo build --all-targets --release
 cd ..

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -1,4 +1,3 @@
-mkdir ~/.cargo
 printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> ~/.cargo/config.toml
 if ! [ -d "./colink-server-dev" ]; then
     git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.gittoml

--- a/compile_release.sh
+++ b/compile_release.sh
@@ -1,9 +1,10 @@
+mkdir ~/.cargo
+printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> ~/.cargo/config.toml
 if ! [ -d "./colink-server-dev" ]; then
     git clone --recursive git@github.com:CoLearn-Dev/colink-server-dev.gittoml
 fi
 cd colink-server-dev
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-sdk-rust-dev" ]; then
@@ -11,7 +12,6 @@ if ! [ -d "./colink-sdk-rust-dev" ]; then
 fi
 cd colink-sdk-rust-dev
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-policy-module-dev" ]; then
@@ -20,7 +20,6 @@ fi
 cd colink-protocol-policy-module-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-remote-storage-dev" ]; then
@@ -29,7 +28,6 @@ fi
 cd colink-protocol-remote-storage-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..
 if ! [ -d "./colink-protocol-registry-dev" ]; then
@@ -38,6 +36,5 @@ fi
 cd colink-protocol-registry-dev
 sed -i '/^colink-sdk =/ccolink-sdk = { path = "../colink-sdk-rust-dev" }' Cargo.toml
 cargo vendor all
-printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "all"\n' >> Cargo.toml
 cargo build --all-targets --release
 cd ..

--- a/install_colink.template.sh
+++ b/install_colink.template.sh
@@ -25,10 +25,6 @@ case "$response" in
         ;;
 esac
 
-if ! [ -f "./mq_prefix.txt" ]; then
-    echo -n "colink-dev-script-$RANDOM" > mq_prefix.txt
-fi
-
 if [ -z $COLINK_HOME ]; then
     COLINK_HOME="$HOME/.colink"
 fi
@@ -37,6 +33,10 @@ mkdir -p $COLINK_HOME
 PAYLOAD_LINE=$(awk '/^__PAYLOAD_BEGINS__/ { print NR + 1; exit 0; }' $0)
 
 tail -n +${PAYLOAD_LINE} $0 | tar -px -C $COLINK_HOME
+
+if ! [ -f "$COLINK_HOME/mq_prefix.txt" ]; then
+    echo -n "colink-dev-script-$RANDOM" > $COLINK_HOME/mq_prefix.txt
+fi
 
 PROFILE=""
 if [ -f "$HOME/.bashrc" ]; then

--- a/install_colink.template.sh
+++ b/install_colink.template.sh
@@ -10,8 +10,6 @@ PAYLOAD_LINE=$(awk '/^__PAYLOAD_BEGINS__/ { print NR + 1; exit 0; }' $0)
 
 tail -n +${PAYLOAD_LINE} $0 | tar -px -C $COLINK_HOME
 
-$COLINK_HOME/colinkctl install
-
 PROFILE=""
 if [ -f "$HOME/.bashrc" ]; then
     PROFILE="$HOME/.bashrc"

--- a/install_colink.template.sh
+++ b/install_colink.template.sh
@@ -25,6 +25,10 @@ case "$response" in
         ;;
 esac
 
+if ! [ -f "./mq_prefix.txt" ]; then
+    echo -n "colink-dev-script-$RANDOM" > mq_prefix.txt
+fi
+
 if [ -z $COLINK_HOME ]; then
     COLINK_HOME="$HOME/.colink"
 fi

--- a/install_colink.template.sh
+++ b/install_colink.template.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 set -e
 
+read -r -p "Install dependencies? [Y/n] " response
+case "$response" in
+    [nN][oO]|[nN])
+        ;;
+    *)
+        sudo apt update && sudo apt install git g++ cmake pkg-config libssl-dev protobuf-compiler lsof -y
+        if ! [ -x "$(command -v cargo)" ]; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            source $HOME/.cargo/env
+            rustup default stable
+        fi
+        read -r -p "Install RabbitMQ? [Y/n] " response
+        case "$response" in
+            [nN][oO]|[nN])
+                ;;
+            *)
+                sudo apt install rabbitmq-server -y
+                sudo rabbitmq-plugins enable rabbitmq_management
+                sudo systemctl restart rabbitmq-server.service
+                ;;
+        esac
+        ;;
+esac
+
 if [ -z $COLINK_HOME ]; then
     COLINK_HOME="$HOME/.colink"
 fi


### PR DESCRIPTION
This PR changes the CI to output precompiled binaries for colink's submodules. To save space, it only moves binaries and their dependencies into the release payload, which can be run to automatically install colink without compilation. The current release comes from this branch if you guys want to test

Considerations - 

The binaries are invoked directly by colinkctl now, rather than through Cargo. 

There may be some more files, like the .d files, that can be removed from the payload. 

It would be a good idea for this branch to get some more testing, especially with the commands related to creating a new protocol. I have only testing the hello world protocol documented on the old quickstart. 

In order to get dependencies to work, I end up vendoring all of them in the CI before compilation.